### PR TITLE
Arreglo creación de eventos

### DIFF
--- a/app/lib/date_time.rb
+++ b/app/lib/date_time.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Extención de clase base
+class DateTime
+  # Cambia el día de semana a la entregada,
+  # solo considerando el dia actual y posteriores
+  def change_to_next_wday(week_day)
+    self + (week_day - wday) % 7
+  end
+end


### PR DESCRIPTION
## Descripción

- Arregla un error en la primera semana del calendario, que causaba que eventos se muestren además en otro día.
- Arregla un error al juntar eventos cuando hay tipos diferentes el mismo día o módulo, que causaba que no se junten los del mismo tipo.
